### PR TITLE
Simplify Java auth and remove possibility of user synchronisation issues

### DIFF
--- a/android/src/main/java/io/fullstack/firestack/FirestackAuth.java
+++ b/android/src/main/java/io/fullstack/firestack/FirestackAuth.java
@@ -19,7 +19,6 @@ import com.facebook.react.bridge.ReactContext;
 
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.FirebaseApp;
 
 import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.AuthResult;
@@ -42,14 +41,12 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
   // private Context context;
   private ReactContext mReactContext;
   private FirebaseAuth mAuth;
-  private FirebaseApp app;
-  private FirebaseUser user;
   private FirebaseAuth.AuthStateListener mAuthListener;
 
   public FirestackAuthModule(ReactApplicationContext reactContext) {
     super(reactContext);
-    // this.context = reactContext;
     mReactContext = reactContext;
+    mAuth = FirebaseAuth.getInstance();
 
    Log.d(TAG, "New FirestackAuth instance");
   }
@@ -78,16 +75,17 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void listenForAuth() {
-    if (mAuthListener == null || mAuth == null) {
+    if (mAuthListener == null) {
       mAuthListener = new FirebaseAuth.AuthStateListener() {
         @Override
         public void onAuthStateChanged(@NonNull FirebaseAuth firebaseAuth) {
+          FirebaseUser user = firebaseAuth.getCurrentUser();
           WritableMap msgMap = Arguments.createMap();
           msgMap.putString("eventName", "listenForAuth");
 
-          if (FirestackAuthModule.this.user != null) {
+          if (user != null) {
             // TODO move to helper
-            WritableMap userMap = getUserMap();
+            WritableMap userMap = getUserMap(user);
             msgMap.putBoolean("authenticated", true);
             msgMap.putMap("user", userMap);
 
@@ -98,8 +96,6 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
           }
         }
       };
-
-      mAuth = FirebaseAuth.getInstance();
       mAuth.addAuthStateListener(mAuthListener);
     }
   }
@@ -119,16 +115,13 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void createUserWithEmail(final String email, final String password, final Callback callback) {
-    mAuth = FirebaseAuth.getInstance();
-
     mAuth.createUserWithEmailAndPassword(email, password)
         .addOnCompleteListener(new OnCompleteListener<AuthResult>() {
           @Override
           public void onComplete(@NonNull Task<AuthResult> task) {
             try {
               if (task.isSuccessful()) {
-                FirestackAuthModule.this.user = task.getResult().getUser();
-                userCallback(FirestackAuthModule.this.user, callback);
+                userCallback(task.getResult().getUser(), callback);
               } else {
                 userErrorCallback(task, callback);
               }
@@ -141,7 +134,6 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void signInWithEmail(final String email, final String password, final Callback callback) {
-    mAuth = FirebaseAuth.getInstance();
 
     mAuth.signInWithEmailAndPassword(email, password)
         .addOnCompleteListener(new OnCompleteListener<AuthResult>() {
@@ -149,8 +141,7 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
           public void onComplete(@NonNull Task<AuthResult> task) {
             try {
               if (task.isSuccessful()) {
-                FirestackAuthModule.this.user = task.getResult().getUser();
-                userCallback(FirestackAuthModule.this.user, callback);
+                userCallback(task.getResult().getUser(), callback);
               } else {
                 userErrorCallback(task, callback);
               }
@@ -175,9 +166,6 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void signInAnonymously(final Callback callback) {
     Log.d(TAG, "signInAnonymously:called:");
-    mAuth = FirebaseAuth.getInstance();
-
-
     mAuth.signInAnonymously()
         .addOnCompleteListener(new OnCompleteListener<AuthResult>() {
           @Override
@@ -186,8 +174,7 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
 
             try {
               if (task.isSuccessful()) {
-                FirestackAuthModule.this.user = task.getResult().getUser();
-                userCallback(FirestackAuthModule.this.user, callback);
+                userCallback(task.getResult().getUser(), callback);
               } else {
                 userErrorCallback(task, callback);
               }
@@ -200,8 +187,6 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void signInWithCustomToken(final String customToken, final Callback callback) {
-    mAuth = FirebaseAuth.getInstance();
-
     mAuth.signInWithCustomToken(customToken)
         .addOnCompleteListener(new OnCompleteListener<AuthResult>() {
           @Override
@@ -209,8 +194,7 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
             Log.d(TAG, "signInWithCustomToken:onComplete:" + task.isSuccessful());
             try {
               if (task.isSuccessful()) {
-                FirestackAuthModule.this.user = task.getResult().getUser();
-                userCallback(FirestackAuthModule.this.user, callback);
+                userCallback(task.getResult().getUser(), callback);
               } else {
                 userErrorCallback(task, callback);
               }
@@ -231,7 +215,7 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void updateUserEmail(final String email, final Callback callback) {
-    FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+    FirebaseUser user = mAuth.getCurrentUser();
 
     if (user != null) {
       user
@@ -242,8 +226,7 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
               try {
                 if (task.isSuccessful()) {
                   Log.d(TAG, "User email address updated");
-                  FirebaseUser u = FirebaseAuth.getInstance().getCurrentUser();
-                  userCallback(u, callback);
+                  userCallback(mAuth.getCurrentUser(), callback);
                 } else {
                   userErrorCallback(task, callback);
                 }
@@ -259,7 +242,7 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void updateUserPassword(final String newPassword, final Callback callback) {
-    FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+    FirebaseUser user = mAuth.getCurrentUser();
 
     if (user != null) {
       user.updatePassword(newPassword)
@@ -269,9 +252,7 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
               try {
                 if (task.isSuccessful()) {
                   Log.d(TAG, "User password updated");
-
-                  FirebaseUser u = FirebaseAuth.getInstance().getCurrentUser();
-                  userCallback(u, callback);
+                  userCallback(mAuth.getCurrentUser(), callback);
                 } else {
                   userErrorCallback(task, callback);
                 }
@@ -287,8 +268,6 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void sendPasswordResetWithEmail(final String email, final Callback callback) {
-    mAuth = FirebaseAuth.getInstance();
-
     mAuth.sendPasswordResetEmail(email)
         .addOnCompleteListener(new OnCompleteListener<Void>() {
           @Override
@@ -310,7 +289,7 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void deleteUser(final Callback callback) {
-    FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+    FirebaseUser user = mAuth.getCurrentUser();
     if (user != null) {
       user.delete()
           .addOnCompleteListener(new OnCompleteListener<Void>() {
@@ -339,7 +318,7 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void sendEmailVerification(final Callback callback) {
-    FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+    FirebaseUser user = mAuth.getCurrentUser();
 
     if (user != null) {
       user.sendEmailVerification()
@@ -371,7 +350,7 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void getToken(final Callback callback) {
-    FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+    FirebaseUser user = mAuth.getCurrentUser();
 
     if (user != null) {
       user.getToken(true)
@@ -403,7 +382,7 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void updateUserProfile(ReadableMap props, final Callback callback) {
-    FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+    FirebaseUser user = mAuth.getCurrentUser();
 
     if (user != null) {
       UserProfileChangeRequest.Builder profileBuilder = new UserProfileChangeRequest.Builder();
@@ -430,8 +409,7 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
               try {
                 if (task.isSuccessful()) {
                   Log.d(TAG, "User profile updated");
-                  FirebaseUser u = FirebaseAuth.getInstance().getCurrentUser();
-                  userCallback(u, callback);
+                  userCallback(mAuth.getCurrentUser(), callback);
                 } else {
                   userErrorCallback(task, callback);
                 }
@@ -447,8 +425,7 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void signOut(final Callback callback) {
-    FirebaseAuth.getInstance().signOut();
-    this.user = null;
+    mAuth.signOut();
 
     WritableMap resp = Arguments.createMap();
     resp.putString("status", "complete");
@@ -458,22 +435,18 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void getCurrentUser(final Callback callback) {
-    mAuth = FirebaseAuth.getInstance();
-
-    this.user = mAuth.getCurrentUser();
-    if (this.user == null) {
+    FirebaseUser user = mAuth.getCurrentUser();
+    if (user == null) {
       callbackNoUser(callback, false);
     } else {
-      Log.d("USRC", this.user.getUid());
-      userCallback(this.user, callback);
+      Log.d("USRC", user.getUid());
+      userCallback(user, callback);
     }
   }
 
   // TODO: Check these things
   @ReactMethod
   public void googleLogin(String IdToken, final Callback callback) {
-    mAuth = FirebaseAuth.getInstance();
-
     AuthCredential credential = GoogleAuthProvider.getCredential(IdToken, null);
     mAuth.signInWithCredential(credential)
         .addOnCompleteListener(new OnCompleteListener<AuthResult>() {
@@ -481,8 +454,7 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
           public void onComplete(@NonNull Task<AuthResult> task) {
             try {
               if (task.isSuccessful()) {
-                FirestackAuthModule.this.user = task.getResult().getUser();
-                userCallback(FirestackAuthModule.this.user, callback);
+                userCallback(task.getResult().getUser(), callback);
               } else {
                 userErrorCallback(task, callback);
               }
@@ -495,8 +467,6 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void facebookLogin(String Token, final Callback callback) {
-    mAuth = FirebaseAuth.getInstance();
-
     AuthCredential credential = FacebookAuthProvider.getCredential(Token);
     mAuth.signInWithCredential(credential)
         .addOnCompleteListener(new OnCompleteListener<AuthResult>() {
@@ -504,8 +474,7 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
           public void onComplete(@NonNull Task<AuthResult> task) {
             try {
               if (task.isSuccessful()) {
-                FirestackAuthModule.this.user = task.getResult().getUser();
-                userCallback(FirestackAuthModule.this.user, callback);
+                userCallback(task.getResult().getUser(), callback);
               } else {
                 userErrorCallback(task, callback);
               }
@@ -517,24 +486,15 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
   }
 
   // Internal helpers
-  private void userCallback(FirebaseUser passedUser, final Callback callback) {
-
-    if (passedUser == null) {
-      mAuth = FirebaseAuth.getInstance();
-      this.user = mAuth.getCurrentUser();
-    } else {
-      this.user = passedUser;
-    }
-
-    if (this.user != null) {
-      this.user.getToken(true).addOnCompleteListener(new OnCompleteListener<GetTokenResult>() {
+  private void userCallback(final FirebaseUser user, final Callback callback) {
+    if (user != null) {
+      user.getToken(true).addOnCompleteListener(new OnCompleteListener<GetTokenResult>() {
         @Override
         public void onComplete(@NonNull Task<GetTokenResult> task) {
           try {
             if (task.isSuccessful()) {
-              WritableMap userMap = getUserMap();
-              final String token = task.getResult().getToken();
-              userMap.putString("token", token);
+              WritableMap userMap = getUserMap(user);
+              userMap.putString("token", task.getResult().getToken());
               callback.invoke(null, userMap);
             } else {
               userErrorCallback(task, callback);
@@ -567,11 +527,8 @@ class FirestackAuthModule extends ReactContextBaseJavaModule {
     onFail.invoke(error);
   }
 
-  private WritableMap getUserMap() {
+  private WritableMap getUserMap(FirebaseUser user) {
     WritableMap userMap = Arguments.createMap();
-
-    FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
-
     if (user != null) {
       final String email = user.getEmail();
       final String uid = user.getUid();

--- a/lib/modules/auth.js
+++ b/lib/modules/auth.js
@@ -26,13 +26,6 @@ export default class Auth extends Base {
     // but this is ok as we fake it with the getCurrentUser below
     FirestackAuthEvt.addListener('listenForAuth', this._onAuthStateChanged.bind(this));
     FirestackAuth.listenForAuth();
-
-    this.getCurrentUser().then((u: Object) => {
-      this._onAuthStateChanged({ authenticated: !!u, user: u || null });
-    }).catch(() => {
-      // todo check if error contains user disabled message maybe and add a disabled flag?
-      this._onAuthStateChanged({ authenticated: false, user: null });
-    });
   }
 
   /**


### PR DESCRIPTION
This changes removes the locally stored FirebaseUser from the auth module to remove any possibility of there being any synchronisation issues.

Instead the user received in the response is always passed back to the JS.