### PR TITLE
Fix JS reference memory leaks

### DIFF
--- a/lib/modules/database/index.js
+++ b/lib/modules/database/index.js
@@ -22,28 +22,20 @@ export default class Database extends Base {
     this.log.debug('Created new Database instance', this.options);
 
     this.persistenceEnabled = false;
-    this.successListener = null;
-    this.errorListener = null;
-    this.refs = {};
-    this.dbSubscriptions = {}; // { path: { modifier: { eventType: [Subscriptions] } } }
+    this.successListener = FirestackDatabaseEvt
+      .addListener(
+        'database_event',
+        event => this.handleDatabaseEvent(event));
+    this.errorListener = FirestackDatabaseEvt
+      .addListener(
+        'database_error',
+        err => this.handleDatabaseError(err));
+
+    this.dbSubscriptions = {};
   }
 
   ref(...path: Array<string>) {
     return new Reference(this, path);
-  }
-
-  storeRef(key: string, instance: Reference): Promise<Reference> {
-    if (!this.refs[key]) {
-      this.refs[key] = instance;
-    }
-    return Promise.resolve(this.refs[key]);
-  }
-
-  unstoreRef(key: string): Promise<void> {
-    if (this.refs[key]) {
-      delete this.refs[key];
-    }
-    return Promise.resolve();
   }
 
   setPersistence(enable: boolean = true) {
@@ -59,148 +51,94 @@ export default class Database extends Base {
     return promise;
   }
 
-  handleDatabaseEvent(evt: Object) {
-    const body = evt.body || {};
-    const path = body.path;
-    const modifiersString = body.modifiersString || '';
-    const modifier = modifiersString;
-    const eventName = body.eventName;
-    this.log.debug('handleDatabaseEvent: ', path, modifiersString, eventName, body.snapshot && body.snapshot.key);
+  handleDatabaseEvent(event: Object) {
+    const body = event.body || {};
+    const { path, modifiersString, eventName, snapshot } = body;
+    const dbHandle = this._dbHandle(path, modifiersString);
+    this.log.debug('handleDatabaseEvent: ', dbHandle, eventName, snapshot && snapshot.key);
 
-    // subscriptionsMap === { path: { modifier: { eventType: [Subscriptions] } } }
-    const modifierMap = this.dbSubscriptions[path];
-    if (modifierMap) {
-      const eventTypeMap = modifierMap[modifier];
-      if (eventTypeMap) {
-        const callbacks = eventTypeMap[eventName] || [];
-        this.log.debug(' -- about to fire its ' + callbacks.length + ' callbacks');
-        callbacks.forEach(cb => {
-          if (cb && typeof(cb) === 'function') {
-            const snap = new Snapshot(this, body.snapshot);
-            cb(snap, body);
-          }
-        });
-      }
-    }
-  }
-
-  handleDatabaseError(evt: Object) {
-    this.log.debug('handleDatabaseError ->', evt);
-  }
-
-  on(referenceKey: string, path: string, modifiersString: string, modifiers: Array<string>, evt: string, cb: () => void) {
-    this.log.debug('adding on listener', referenceKey, path, modifiers, evt);
-    const key = this._pathKey(path);
-
-    if (!this.dbSubscriptions[key]) {
-      this.dbSubscriptions[key] = {};
-    }
-
-    if (!this.dbSubscriptions[key][modifiersString]) {
-      this.dbSubscriptions[key][modifiersString] = {};
-    }
-
-    if (!this.dbSubscriptions[key][modifiersString][evt]) {
-      this.dbSubscriptions[key][modifiersString][evt] = [];
-    }
-
-    this.dbSubscriptions[key][modifiersString][evt].push(cb);
-
-    if (!this.successListener) {
-      this.successListener = FirestackDatabaseEvt
-        .addListener(
-          'database_event',
-          this.handleDatabaseEvent.bind(this));
-    }
-
-    if (!this.errorListener) {
-      this.errorListener = FirestackDatabaseEvt
-        .addListener(
-          'database_error',
-          this.handleDatabaseError.bind(this));
-    }
-
-    return promisify('on', FirestackDatabase)(path, modifiersString, modifiers, evt).then(() => {
-      return [this.successListener, this.errorListener];
-    });
-  }
-
-  off(referenceKey: string, path: string, modifiersString: string, modifiers: Array<string>, eventName: string, origCB?: () => void) {
-    const pathKey = this._pathKey(path);
-    this.log.debug('off() : ', referenceKey, pathKey, modifiersString, eventName);
-    // Remove subscription
-    if (this.dbSubscriptions[pathKey]) {
-
-      if (!eventName || eventName === '') {
-        // remove all listeners for this pathKey
-        this.dbSubscriptions[pathKey] = {};
-      }
-
-      // TODO clean me - no need for this many conditionals
-      if (this.dbSubscriptions[pathKey][modifiersString]) {
-        if (this.dbSubscriptions[pathKey][modifiersString][eventName]) {
-          if (origCB) {
-            // remove only the given callback
-            this.dbSubscriptions[pathKey][modifiersString][eventName].splice(this.dbSubscriptions[pathKey][modifiersString][eventName].indexOf(origCB), 1);
-          } else {
-            // remove all callbacks for this path:modifier:eventType
-            delete this.dbSubscriptions[pathKey][modifiersString][eventName];
-          }
-        } else {
-          this.log.warn('off() called, but not currently listening at that location (bad eventName)', pathKey, modifiersString, eventName);
+    if (this.dbSubscriptions[dbHandle] && this.dbSubscriptions[dbHandle][eventName]) {
+      this.dbSubscriptions[dbHandle][eventName].forEach(cb => {
+        if (cb && typeof(cb) === 'function') {
+          const snap = new Snapshot(this, snapshot);
+          cb(snap, body);
         }
+      })
+    } else {
+      FirestackDatabase.off(path, modifiersString, eventName, () => {
+        this.log.debug('handleDatabaseEvent: No JS listener registered, removed native listener', dbHandle, eventName);
+      });
+    }
+  }
+
+  handleDatabaseError(err: Object) {
+    this.log.debug('handleDatabaseError ->', err);
+  }
+
+  on(path: string, modifiersString: string, modifiers: Array<string>, eventName: string, cb: () => void) {
+    const dbHandle = this._dbHandle(path, modifiersString);
+    this.log.debug('adding on listener', dbHandle);
+    
+    if (this.dbSubscriptions[dbHandle]) {
+      if (this.dbSubscriptions[dbHandle][eventName]) {
+        this.dbSubscriptions[dbHandle][eventName].push(cb);
       } else {
-        this.log.warn('off() called, but not currently listening at that location (bad modifier)', pathKey, modifiersString, eventName);
-      }
-
-      if (Object.keys(this.dbSubscriptions[pathKey]).length <= 0) {
-        // there are no more subscriptions so we can unwatch
-        delete this.dbSubscriptions[pathKey];
-      }
-      if (Object.keys(this.dbSubscriptions).length === 0) {
-        if (this.successListener) {
-          this.successListener.remove();
-          this.successListener = null;
-        }
-        if (this.errorListener) {
-          this.errorListener.remove();
-          this.errorListener = null;
-        }
+        this.dbSubscriptions[dbHandle][eventName] = [cb];
       }
     } else {
-      this.log.warn('off() called, but not currently listening at that location (bad path)', pathKey, modifiersString, eventName);
+      this.dbSubscriptions[dbHandle] = {
+        [eventName]: [cb]
+      }
     }
 
-    const subscriptions = [this.successListener, this.errorListener];
-    const modifierMap = this.dbSubscriptions[path];
+    return promisify('on', FirestackDatabase)(path, modifiersString, modifiers, eventName);
+  }
 
-    if (modifierMap && modifierMap[modifiersString] && modifierMap[modifiersString][eventName] && modifierMap[modifiersString][eventName].length > 0) {
-      return Promise.resolve(subscriptions);
+  off(path: string, modifiersString: string, eventName?: string, origCB?: () => void) {
+    const dbHandle = this._dbHandle(path, modifiersString);
+    this.log.debug('off() : ', dbHandle, eventName);
+
+    if (!this.dbSubscriptions[dbHandle]
+      || (eventName && !this.dbSubscriptions[dbHandle][eventName])) {
+      this.log.warn('off() called, but not currently listening at that location (bad path)', dbHandle, eventName);
+      return Promise.resolve();
     }
 
-    return promisify('off', FirestackDatabase)(path, modifiersString, eventName).then(() => {
-      // subscriptions.forEach(sub => sub.remove());
-      // delete this.listeners[eventName];
-      return subscriptions;
-    });
+    if (eventName && origCB) {
+      const i = this.dbSubscriptions[dbHandle][eventName].indexOf(origCB);
+      if (i === -1) {
+        this.log.warn('off() called, but the callback specifed is not listening at that location (bad path)', dbHandle, eventName);
+        return Promise.resolve();
+      } else {
+        this.dbSubscriptions[dbHandle][eventName] = this.dbSubscriptions[dbHandle][eventName].splice(i, 1);
+        if (this.dbSubscriptions[dbHandle][eventName].length > 0) {
+          return Promise.resolve();
+        }
+      }
+    } else if (eventName) {
+      this.dbSubscriptions[dbHandle][eventName] = [];
+    } else {
+      this.dbSubscriptions[dbHandle] = {}
+    }
+    return promisify('off', FirestackDatabase)(path, modifiersString, eventName);
   }
 
   cleanup() {
-    let promises = Object.keys(this.refs)
-      .map(key => this.refs[key])
-      .map(ref => ref.cleanup());
+    let promises = [];
+    Object.keys(this.dbSubscriptions).forEach(dbHandle => {
+      Object.keys(this.dbSubscriptions[dbHandle]).forEach(eventName => {
+        let separator = dbHandle.indexOf('|');
+        let path = dbHandle.substring(0, separator);
+        let modifiersString = dbHandle.substring(separator + 1);
+        
+        promises.push(this.off(path, modifiersString, eventName))
+      })
+    })
     return Promise.all(promises);
   }
 
-  release(...path: Array<string>) {
-    const key = this._pathKey(...path);
-    if (this.refs[key]) {
-      delete this.refs[key];
-    }
-  }
-
-  _pathKey(...path: Array<string>): string {
-    return path.join('-');
+  _dbHandle(path: string = '', modifiersString: string = '') {
+    return path + '|' + modifiersString;
   }
 
   goOnline() {

--- a/lib/modules/database/reference.js
+++ b/lib/modules/database/reference.js
@@ -12,7 +12,6 @@ import { promisify, isFunction, isObject, tryJSONParse, tryJSONStringify, genera
 const FirestackDatabase = NativeModules.FirestackDatabase;
 
 // https://firebase.google.com/docs/reference/js/firebase.database.Reference
-let uid = 0;
 
 /**
  * @class Reference
@@ -21,16 +20,13 @@ export default class Reference extends ReferenceBase {
 
   db: FirestackDatabase;
   query: Query;
-  uid: number;
 
   constructor(db: FirestackDatabase, path: Array<string>, existingModifiers?: Array<string>) {
     super(db.firestack, path);
 
     this.db = db;
-    this.uid = uid += 1;
-    this.listeners = {};
     this.query = new Query(this, path, existingModifiers);
-    this.log.debug('Created new Reference', this.dbPath(), this.uid);
+    this.log.debug('Created new Reference', this.db._dbHandle(path, existingModifiers));
   }
 
   child(...paths: Array<string>) {
@@ -40,15 +36,6 @@ export default class Reference extends ReferenceBase {
   keepSynced(bool: boolean) {
     const path = this.dbPath();
     return promisify('keepSynced', FirestackDatabase)(path, bool);
-  }
-
-  // Get the value of a ref either with a key
-  // todo - where is this on the FB JS api - seems just like another random function
-  get() {
-    const path = this.dbPath();
-    const modifiers = this.query.getModifiers();
-    const modifiersString = this.query.getModifiersString();
-    return promisify('onOnce', FirestackDatabase)(path, modifiersString, modifiers, 'value');
   }
 
   set(value: any) {
@@ -93,49 +80,31 @@ export default class Reference extends ReferenceBase {
       });
   }
 
-  on(evt?: string, cb: () => any) {
+  on(eventName: string, cb: () => any) {
     const path = this.dbPath();
     const modifiers = this.query.getModifiers();
     const modifiersString = this.query.getModifiersString();
-    this.log.debug('adding reference.on', path, modifiersString, evt);
-    return this.db.storeRef(this.uid, this).then(() => {
-      return this.db.on(this.uid, path, modifiersString, modifiers, evt, cb).then((subscriptions) => {
-        this.listeners[evt] = subscriptions;
+    this.log.debug('adding reference.on', path, modifiersString, eventName);
+    return this.db.on(path, modifiersString, modifiers, eventName, cb);
+  }
+
+  once(eventName: string = 'once', cb: (snapshot: Object) => void) {
+    const path = this.dbPath();
+    const modifiers = this.query.getModifiers();
+    const modifiersString = this.query.getModifiersString();
+    return promisify('onOnce', FirestackDatabase)(path, modifiersString, modifiers, eventName)
+      .then(({ snapshot }) => new Snapshot(this, snapshot))
+      .then((snapshot) => {
+        if (isFunction(cb)) cb(snapshot);
+        return snapshot;
       });
-    });
   }
 
-  once(evt?: string = 'once', cb: (snapshot: Object) => void) {
+  off(eventName?: string = '', origCB?: () => any) {
     const path = this.dbPath();
-    const modifiers = this.query.getModifiers();
     const modifiersString = this.query.getModifiersString();
-    return this.db.storeRef(this.uid, this).then(() => {
-      // todo use event emitter - not callbacks
-      return promisify('onOnce', FirestackDatabase)(path, modifiersString, modifiers, evt)
-        .then(({ snapshot }) => new Snapshot(this, snapshot))
-        .then((snapshot) => {
-          if (isFunction(cb)) cb(snapshot);
-          return snapshot;
-        });
-    });
-  }
-
-  off(evt: string = '', origCB?: () => any) {
-    const path = this.dbPath();
-    const modifiers = this.query.getModifiers();
-    const modifiersString = this.query.getModifiersString();
-    this.log.debug('ref.off(): ', path, modifiers, evt);
-    return this.db.unstoreRef(this.uid).then(() => {
-      return this.db.off(this.uid, path, modifiersString, modifiers, evt, origCB).then(() => {
-        // todo urm - whats this?
-        // delete this.listeners[eventName];
-        // this.listeners[evt] = subscriptions;
-      });
-    });
-  }
-
-  cleanup() {
-    return Promise.all(Object.keys(this.listeners).map(key => this.off(key)));
+    this.log.debug('ref.off(): ', path, modifiersString, eventName);
+    return this.db.off(path, modifiersString, eventName, origCB);
   }
 
   /**


### PR DESCRIPTION
First attempt at fixing possible JS reference memory leaks.

I haven't switched to using an EventEmitter as I don't think it will simplify the code any further.  What I have done is make sure that it is only the database object that knows which subscriptions exist.  Previously both the database and each reference held links to the listeners/reference objects which is where I think the memory leaks were happening.