### PR TITLE
Pass child snapshot instead of child object to forEach fn

### DIFF
--- a/lib/modules/database/snapshot.js
+++ b/lib/modules/database/snapshot.js
@@ -51,7 +51,7 @@ export default class Snapshot {
   }
 
   forEach(fn: (key: any) => any) {
-    return this.childKeys.forEach((key, i) => fn(this.value[key], i));
+    return this.childKeys.forEach((key, i) => fn(this.child(key), i));
   }
 
   getPriority() {


### PR DESCRIPTION
This matches the Firebase Web SDK behaviour.