### PR TITLE
Fix increment bug caused by return value of addition assignment

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -33,7 +33,7 @@ export function deepGet(object, path, joiner = '/') {
   const len = keys.length;
 
   while (i < len) {
-    const key = keys[i += 1];
+    const key = keys[i++];
     if (!tmp || !hasOwnProperty.call(tmp, key)) return null;
     tmp = tmp[key];
   }
@@ -57,7 +57,7 @@ export function deepExists(object, path, joiner = '/') {
   const len = keys.length;
 
   while (i < len) {
-    const key = keys[i += 1];
+    const key = keys[i++];
     if (!tmp || !hasOwnProperty.call(tmp, key)) return false;
     tmp = tmp[key];
   }


### PR DESCRIPTION
This fixes something that was reverted in 386be3d0b118256ca510bbe78ad21c4748b8f7d9.

```js
let i = 0
i += 1 // returns 1
```
is not the same as
```js
let i = 0
i++ // returns 0
```