### PR TITLE
Fix error from firebase for login with credentials

### DIFF
--- a/android/src/main/java/io/fullstack/firestack/auth/FirestackAuth.java
+++ b/android/src/main/java/io/fullstack/firestack/auth/FirestackAuth.java
@@ -25,12 +25,10 @@ import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.UserProfileChangeRequest;
 import com.google.firebase.auth.FacebookAuthProvider;
 import com.google.firebase.auth.FirebaseAuth;
-import com.google.firebase.auth.FirebaseAuthException;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.auth.GetTokenResult;
 import com.google.firebase.auth.GoogleAuthProvider;
 import com.google.firebase.auth.EmailAuthProvider;
-
 
 import io.fullstack.firestack.Utils;
 
@@ -576,7 +574,6 @@ public class FirestackAuth extends ReactContextBaseJavaModule {
 
   private void userErrorCallback(Task task, final Callback onFail) {
     WritableMap error = Arguments.createMap();
-    error.putString("code", ((FirebaseAuthException) task.getException()).getErrorCode());
     error.putString("message", task.getException().getMessage());
     onFail.invoke(error);
   }


### PR DESCRIPTION
Fix error message from firebase for login with credentials : Wrong cast of FirebaseAuthException. Cannot get the error code, it is included in the error message. With this fix, you will get (for exemple) :
User signin error', { code: '', message: 'An internal error has occurred. [ invalid access_token, error code 43. ]' }