### PR TITLE
Replaced "facebook.com' to 'facebook'

### DIFF
--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -210,7 +210,7 @@ Reauthenticate the current user with credentials:
 
 ```javascript
 const credentials = {
-  provider: 'facebook.com', 
+  provider: 'facebook', 
   token: '12345', 
   secret: '6789', 
 };


### PR DESCRIPTION
Replaced "facebook.com' to 'facebook' in the exemple of login with providers